### PR TITLE
Added auto word wrap for text

### DIFF
--- a/tingbot/graphics.py
+++ b/tingbot/graphics.py
@@ -153,8 +153,6 @@ class Surface(object):
         realXY = _xy_multiply(xy, _anchor(align))
 
         if((text_image.size[0] + realXY[0] > 320) and auto_word_wrap):
-            print(text_image.size[0] + realXY[0])
-            print(text_image.size[0])
             lines = int(math.ceil((text_image.size[0] + realXY[0])/320.0))
             words = string.split()
             count = 0
@@ -168,9 +166,10 @@ class Surface(object):
                     lineStr += words[count] + " "
                     count += 1
                 self.text(lineStr, xy=(xy[0], xy[1]+line*text_image.size[1]), color=color, align=align, font_size=font_size)
-            return lines * xy[1]
+            return (text_image.size[0],  lines * text_image.size[1])
 
         self.image(text_image, xy, align=align)
+        return text_image.size
 
     def rectangle(self, xy=None, size=(100, 100), color='grey', align='center'):
         if len(size) != 2:
@@ -226,8 +225,9 @@ class Screen(Surface):
         self.needs_update = True
 
     def text(self, *args, **kwargs):
-        super(Screen, self).text(*args, **kwargs)
+        size = super(Screen, self).text(*args, **kwargs)
         self.needs_update = True
+        return size
 
     def rectangle(self, *args, **kwargs):
         super(Screen, self).rectangle(*args, **kwargs)

--- a/tingbot/graphics.py
+++ b/tingbot/graphics.py
@@ -1,5 +1,6 @@
 import os, time, numbers
 import pygame
+import math
 from . import platform_specific
 from .utils import cached_property
 
@@ -140,7 +141,7 @@ class Surface(object):
     def fill(self, color):
         self.surface.fill(_color(color))
 
-    def text(self, string, xy=None, color='grey', align='center', font=None, font_size=32, antialias=None):
+    def text(self, string, xy=None, color='grey', align='center', font=None, font_size=32, antialias=None, auto_word_wrap = True):
         font, antialias = _font(font, font_size, antialias)
         string = unicode(string)
 
@@ -148,6 +149,26 @@ class Surface(object):
             antialias
 
         text_image = Image(surface=font.render(string, antialias, _color(color)))
+
+        realXY = _xy_multiply(xy, _anchor(align))
+
+        if((text_image.size[0] + realXY[0] > 320) and auto_word_wrap):
+            print(text_image.size[0] + realXY[0])
+            print(text_image.size[0])
+            lines = int(math.ceil((text_image.size[0] + realXY[0])/320.0))
+            words = string.split()
+            count = 0
+            for line in range(0,lines) :
+                lineStr = ""
+                possibleStr = ""
+                while count <= len(words)-1:
+                    possibleStr += words[count] + " "
+                    if(len(possibleStr) >= 55) :
+                        break
+                    lineStr += words[count] + " "
+                    count += 1
+                self.text(lineStr, xy=(xy[0], xy[1]+line*text_image.size[1]), color=color, align=align, font_size=font_size)
+            return lines * xy[1]
 
         self.image(text_image, xy, align=align)
 


### PR DESCRIPTION
This pull request enables auto word wrapping for text. This means that if the text would flow over the screen, it is prevented. It also adds the possibility of getting back the size of the text created. This allows for better layout managing.

**Before:**
![before](https://cloud.githubusercontent.com/assets/5339762/11452200/3f1277d4-95e0-11e5-843f-14b9ddee0e51.png)

**After:**
![after](https://cloud.githubusercontent.com/assets/5339762/11452201/4b254c68-95e0-11e5-929d-63707e228343.png)

Example:

``` python
size = screen.text(
                "Very long text that spans across the whole screen and therefore needs be split up into two lines."
                xy=(0, 0),
                color='white',
                font_size=20,
            )
print(size) #gives you (450, 40)
```
