### PR TITLE
Add Basic Windows Compatibility

### DIFF
--- a/tingbot/platform_specific/__init__.py
+++ b/tingbot/platform_specific/__init__.py
@@ -2,5 +2,7 @@ import platform
 
 if platform.system() == 'Darwin':
     from osx import fixup_env, fixup_window, register_button_callback
+elif platform.system() == 'Windows':
+    from win import fixup_env, fixup_window, register_button_callback
 else:
     from pi import fixup_env, fixup_window, register_button_callback

--- a/tingbot/platform_specific/win.py
+++ b/tingbot/platform_specific/win.py
@@ -1,0 +1,29 @@
+import os
+
+window_controller = None
+
+def fixup_window():
+    window_controller = None
+
+
+def fixup_env():
+    import pygame
+    icon_file = os.path.join(os.path.dirname(__file__), 'simulator-icon.png')
+    pygame.display.set_icon(pygame.image.load(icon_file))
+    pygame.display.set_caption("TingbotSimulator")
+
+button_callback = None
+
+
+def register_button_callback(callback):
+    '''
+    callback(button_index, action)
+        button_index is a zero-based index that identifies which button has been pressed
+        action is either 'down', or 'up'.
+
+    The callback might not be called on the main thread.
+
+    Currently only 'down' is implemented.
+    '''
+    global button_callback
+    button_callback = callback


### PR DESCRIPTION
Basic port to allow windows users to execute tingbot apps (so long as they have the right dependencies) 
