### PR TITLE
Remove modules.rst

### DIFF
--- a/docs/modules.rst
+++ b/docs/modules.rst
@@ -1,7 +1,0 @@
-tingbot
-=======
-
-.. toctree::
-   :maxdepth: 4
-
-   tingbot


### PR DESCRIPTION
This file does not seem to be necessary and causes several warnings to be generated
when building the documentation
