### PR TITLE
Settings

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -15,3 +15,4 @@ docs/_build
 build/
 dist/
 tingbot.egg-info
+.eggs/

--- a/docs/reference.rst
+++ b/docs/reference.rst
@@ -249,7 +249,7 @@ elsewhere on the internet.
 Settings
 --------
 
-You can store local data on the tingbot. Simply use `tingbot.config` as a `dict <http://learnpythonthehardway.org/book/ex39.html>`_. This will store
+You can store local data on the tingbot. Simply use `tingbot.app.settings` as a `dict <http://learnpythonthehardway.org/book/ex39.html>`_. This will store
 any variables you like on a file in the application directory (called local_settings.json). This is
 stored in `JSON <http://www.w3resource.com/JSON/introduction.php>`_ format. As a developer you can also supply
 default settings for your app to start off with - specify these in default_settings.json. 
@@ -259,31 +259,31 @@ default settings for your app to start off with - specify these in default_setti
     import tingbot
     
     #store an item
-    tingbot.config['favourite_colour'] = 'red'
+    tingbot.app.settings['favourite_colour'] = 'red'
     
     #local_settings.json on disk now contains: {"favourite_colour":"red"}
     
     #retrieve an item
-    tingbot.screen.fill(tingbot.config['favourite_colour'])
+    tingbot.screen.fill(tingbot.app.settings['favourite_colour'])
 
-Any item that can be converted into text can be used in tingbot.config - so strings, ints, floats, and even dicts
-and lists can be used. However, beware, because if you assign to a subitem of `tingbot.config`, this will not be
-automatically saved to disk. You can force a save by calling `tingbot.config.save()`
+Any item that can be converted into text can be used in tingbot.app.settings - so strings, ints, floats, and even dicts
+and lists can be used. However, beware, because if you assign to a subitem of `tingbot.app.settings`, this will not be
+automatically saved to disk. You can force a save by calling `tingbot.app.settings.save()`
 
 .. code-block:: python
 
     import tingbot
     
     #create a sub-dictionary
-    tingbot.config['ages'] = {'Phil':39,'Mabel',73}
+    tingbot.app.settings['ages'] = {'Phil':39,'Mabel',73}
     
     #local_settings.json on disk now contains: {"ages":{"Phil":39,"Mabel":73}}
     
-    tingbot.config['ages']['Barry'] = 74
+    tingbot.app.settings['ages']['Barry'] = 74
     
-    #Warning: local_settings.json has not been updated because you haven't directly changed tingbot.config
+    #Warning: local_settings.json has not been updated because you haven't directly changed tingbot.app.settings
     
-    tingbot.config.save()
+    tingbot.app.settings.save()
     
     #now local_settings.json on disk now contains: {"ages":{"Phil":39,"Mabel":73,"Barry":74}}
 

--- a/docs/reference.rst
+++ b/docs/reference.rst
@@ -244,6 +244,49 @@ elsewhere on the internet.
 
     `IFTTT <http://ifttt.com>`_ is a great place to start for ideas for webhooks. 
     `Slack <http://slack.com>`_ also has native support for webhooks!
+    
+    
+Settings
+--------
+
+You can store local data on the tingbot. Simply use `tingbot.config` as a `dict <http://learnpythonthehardway.org/book/ex39.html>`_. This will store
+any variables you like on a file in the application directory (called local_settings.json). This is
+stored in `JSON <http://www.w3resource.com/JSON/introduction.php>`_ format. As a developer you can also supply
+default settings for your app to start off with - specify these in default_settings.json. 
+
+.. code-block:: python
+
+    import tingbot
+    
+    #store an item
+    tingbot.config['favourite_colour'] = 'red'
+    
+    #local_settings.json on disk now contains: {"favourite_colour":"red"}
+    
+    #retrieve an item
+    tingbot.screen.fill(tingbot.config['favourite_colour'])
+
+Any item that can be converted into text can be used in tingbot.config - so strings, ints, floats, and even dicts
+and lists can be used. However, beware, because if you assign to a subitem of `tingbot.config`, this will not be
+automatically saved to disk. You can force a save by calling `tingbot.config.save()`
+
+.. code-block:: python
+
+    import tingbot
+    
+    #create a sub-dictionary
+    tingbot.config['ages'] = {'Phil':39,'Mabel',73}
+    
+    #local_settings.json on disk now contains: {"ages":{"Phil":39,"Mabel":73}}
+    
+    tingbot.config['ages']['Barry'] = 74
+    
+    #Warning: local_settings.json has not been updated because you haven't directly changed tingbot.config
+    
+    tingbot.config.save()
+    
+    #now local_settings.json on disk now contains: {"ages":{"Phil":39,"Mabel":73,"Barry":74}}
+
 
 Run loop
 --------

--- a/setup.py
+++ b/setup.py
@@ -44,6 +44,7 @@ setup(
         'console_scripts': [
             'tbtool = tbtool.__main__:main',
         ],
+    },
+    test_suite='tests',
 
-    }
 )

--- a/tests/settings_test.py
+++ b/tests/settings_test.py
@@ -1,0 +1,63 @@
+import unittest
+import tingbot.settings as settings
+import json
+
+def fake_load_json(filename):
+    if filename == settings.default_settings:
+        return {'a':1, 'b':2, 'c':3}
+    elif filename == settings.gui_settings:
+        return {'b':4, 'c':5}
+    elif filename == settings.app_settings:
+        return {'c':6}
+
+class TestSettings(unittest.TestCase):
+    def setUp(self):
+        #monkey patch load and save functions
+        self.load_json_old = settings.load_json
+        settings.load_json = fake_load_json
+        self.json_dump_old = json.dump
+        json.dump = self.fake_json_dump
+        self.settings = settings.SettingsDict()
+        
+    def tearDown(self):
+        json.dump = self.json_dump_old
+        settings.load_json = self.load_json_old
+        
+    def fake_json_dump(self,fp,obj):
+        self.json_output = json.loads(json.dumps(obj))
+        
+    def test_simple_assign_and_retrieve(self):
+        self.settings['fred'] = 12
+        self.assertEqual(self.settings['fred'],12)
+        
+    def test_load_from_defaults(self):
+        self.assertEqual(self.settings['a'],1)
+        
+    def test_load_from_gui(self):
+        self.assertEqual(self.settings['b'],4)
+
+    def test_load_from_locals(self):
+        self.assertEqual(self.settings['c'],6)
+        
+    def test_save_updates_only_local_vars(self):
+        self.settings.load()
+        self.settings.save()
+        self.assertEqual(self.json_output,{'c':6})
+    
+    def test_assign_to_existing(self):
+        self.settings['a'] = 25
+        self.assertEqual(self.json_output,{'a':25,'c':6})
+        
+    def test_update_existing(self):
+        self.settings['c'] = 8
+        self.assertEqual(self.json_output,{'c':8})
+        
+    def test_assign_to_new_key(self):
+        self.settings['fred'] = 15
+        self.assertEqual(self.json_output,{'fred':15,'c':6})
+
+    @unittest.expectedFailure                
+    def test_assign_to_subkey(self):
+        self.settings['map'] = {}
+        self.settings['map']['subkey'] = 12
+        self.assertEqual(self.json_output,{'map':{'subkey':12},'c':6})

--- a/tests/settings_test.py
+++ b/tests/settings_test.py
@@ -14,16 +14,16 @@ class TestSettings(unittest.TestCase):
     def setUp(self):
         #monkey patch load and save functions
         self.load_json_old = settings.load_json
+        self.save_json_old = settings.save_json
         settings.load_json = fake_load_json
-        self.json_dump_old = json.dump
-        json.dump = self.fake_json_dump
+        settings.save_json = self.fake_save_json
         self.settings = settings.SettingsDict()
         
     def tearDown(self):
-        json.dump = self.json_dump_old
+        settings.save_json = self.save_json_old
         settings.load_json = self.load_json_old
         
-    def fake_json_dump(self,fp,obj):
+    def fake_save_json(self,fp,obj):
         self.json_output = json.loads(json.dumps(obj))
         
     def test_simple_assign_and_retrieve(self):

--- a/tests/tingapp_test.py
+++ b/tests/tingapp_test.py
@@ -1,29 +1,29 @@
 import unittest
-import tingbot.settings as settings
+import tingbot.tingapp as tingapp
 import json
 
-def fake_load_json(filename):
-    if filename == settings.default_settings:
+def fake_load_json(path,filename):
+    if filename == tingapp.default_settings:
         return {'a':1, 'b':2, 'c':3}
-    elif filename == settings.gui_settings:
+    elif filename == tingapp.general_settings:
         return {'b':4, 'c':5}
-    elif filename == settings.app_settings:
+    elif filename == tingapp.local_settings:
         return {'c':6}
 
 class TestSettings(unittest.TestCase):
     def setUp(self):
         #monkey patch load and save functions
-        self.load_json_old = settings.load_json
-        self.save_json_old = settings.save_json
-        settings.load_json = fake_load_json
-        settings.save_json = self.fake_save_json
-        self.settings = settings.SettingsDict()
+        self.load_json_old = tingapp.load_json
+        self.save_json_old = tingapp.save_json
+        tingapp.load_json = fake_load_json
+        tingapp.save_json = self.fake_save_json
+        self.settings = tingapp.SettingsDict('fake_dir')
         
     def tearDown(self):
-        settings.save_json = self.save_json_old
-        settings.load_json = self.load_json_old
+        tingapp.save_json = self.save_json_old
+        tingapp.load_json = self.load_json_old
         
-    def fake_save_json(self,fp,obj):
+    def fake_save_json(self,path,filename,obj):
         self.json_output = json.loads(json.dumps(obj))
         
     def test_simple_assign_and_retrieve(self):

--- a/tingbot/__init__.py
+++ b/tingbot/__init__.py
@@ -22,7 +22,7 @@ from .run_loop import main_run_loop, every, once
 from .input import touch
 from .button import press
 from .web import webhook
-from .settings import config
+from .tingapp import app
 
 platform_specific.fixup_env()
 

--- a/tingbot/__init__.py
+++ b/tingbot/__init__.py
@@ -22,6 +22,7 @@ from .run_loop import main_run_loop, every, once
 from .input import touch
 from .button import press
 from .web import webhook
+from .settings import config
 
 platform_specific.fixup_env()
 

--- a/tingbot/settings.py
+++ b/tingbot/settings.py
@@ -6,7 +6,7 @@ import sys
 module_dir = os.path.dirname(os.path.abspath(sys.argv[0]))
 default_settings = os.path.join(module_dir,'default_settings.json')
 gui_settings = os.path.join(module_dir,'gui_settings.json')
-app_settings = os.path.join(module_dir,'app_settings.json')
+app_settings = os.path.join(module_dir,'local_settings.json')
 print default_settings,gui_settings,app_settings
 
 def load_json(filename):
@@ -20,6 +20,10 @@ def load_json(filename):
     except IOError,ValueError:
         #either non-existent file or empty filename
         return {}
+
+def save_json(filname,obj):
+    with open(app_settings,'w') as fp:
+        json.dump(filename,obj)
 
 class SettingsDict(collections.MutableMapping):
 
@@ -62,7 +66,6 @@ class SettingsDict(collections.MutableMapping):
         self.loaded = True            
     
     def save(self):
-        with open(app_settings,'w') as fp:
-            json.dump(fp,self.local_settings)
+        save_json(app_settings,self.local_settings)
             
 config = SettingsDict()

--- a/tingbot/settings.py
+++ b/tingbot/settings.py
@@ -1,0 +1,68 @@
+import collections
+import json
+import os
+import sys
+
+module_dir = os.path.dirname(os.path.abspath(sys.argv[0]))
+default_settings = os.path.join(module_dir,'default_settings.json')
+gui_settings = os.path.join(module_dir,'gui_settings.json')
+app_settings = os.path.join(module_dir,'app_settings.json')
+print default_settings,gui_settings,app_settings
+
+def load_json(filename):
+    try:
+        with open(filename,'r') as fp:
+            result = json.load(fp)
+            if isinstance(result,dict):
+                return result
+            else:
+                return {}
+    except IOError,ValueError:
+        #either non-existent file or empty filename
+        return {}
+
+class SettingsDict(collections.MutableMapping):
+
+    def __init__(self):
+        #note we do NOT initialise self.dct or self.local_settings here - this ensures we
+        #raise an error in the event that they are accessed before self.load
+        self.loaded = False
+    
+    def __contains__(self,item):
+        return item in self.dct
+        
+    def __len__(self):
+        print "__len__"
+        return len(self.dct)
+        
+    def __getitem__(self,key):
+        if not self.loaded:
+            self.load()
+        return self.dct[key]
+     
+    def __setitem__(self,key,value):
+        if not self.loaded:
+            self.load()
+        self.dct[key] = value
+        self.local_settings[key] = value
+        self.save()
+        
+    def __delitem__(self,key):
+        del self.dct[key]
+        
+    def __iter__(self):
+        return iter(self.dct)
+        
+        
+    def load(self):
+        self.dct = load_json(default_settings)
+        self.dct.update(load_json(gui_settings))
+        self.local_settings = load_json(app_settings)
+        self.dct.update(self.local_settings)
+        self.loaded = True            
+    
+    def save(self):
+        with open(app_settings,'w') as fp:
+            json.dump(fp,self.local_settings)
+            
+config = SettingsDict()

--- a/tingbot/tingapp.py
+++ b/tingbot/tingapp.py
@@ -3,13 +3,13 @@ import json
 import os
 import sys
 
-module_dir = os.path.dirname(os.path.abspath(sys.argv[0]))
-default_settings = os.path.join(module_dir,'default_settings.json')
-gui_settings = os.path.join(module_dir,'gui_settings.json')
-app_settings = os.path.join(module_dir,'local_settings.json')
-print default_settings,gui_settings,app_settings
+default_settings = 'default_settings.json'
+general_settings = 'settings.json'
+local_settings = 'local_settings.json'
+info_file = 'app.tbinfo'
 
-def load_json(filename):
+def load_json(path,filename):
+    filename = os.path.join(path,filename)
     try:
         with open(filename,'r') as fp:
             result = json.load(fp)
@@ -21,16 +21,18 @@ def load_json(filename):
         #either non-existent file or empty filename
         return {}
 
-def save_json(filname,obj):
+def save_json(path,filename,obj):
+    filename = os.path.join(path,filename)
     with open(app_settings,'w') as fp:
         json.dump(filename,obj)
 
 class SettingsDict(collections.MutableMapping):
 
-    def __init__(self):
+    def __init__(self,path):
         #note we do NOT initialise self.dct or self.local_settings here - this ensures we
         #raise an error in the event that they are accessed before self.load
         self.loaded = False
+        self.path = path
     
     def __contains__(self,item):
         return item in self.dct
@@ -59,13 +61,22 @@ class SettingsDict(collections.MutableMapping):
         
         
     def load(self):
-        self.dct = load_json(default_settings)
-        self.dct.update(load_json(gui_settings))
-        self.local_settings = load_json(app_settings)
+        self.dct = load_json(self.path,default_settings)
+        self.dct.update(load_json(self.path,general_settings))
+        self.local_settings = load_json(self.path,local_settings)
         self.dct.update(self.local_settings)
         self.loaded = True            
     
     def save(self):
-        save_json(app_settings,self.local_settings)
+        save_json(self.path,local_settings,self.local_settings)
+        
+class TingApp(object):
+    def __init__(self,path=None):
+        """path is the root path of the app you want to inspect
+           if path is None, then will let you inspect the current app"""
+        if path is None:
+            path = os.path.dirname(os.path.abspath(sys.argv[0]))
+        self.info = load_json(path,info_file)
+        self.settings = SettingsDict(path)
             
-config = SettingsDict()
+app = TingApp()


### PR DESCRIPTION
This pull request implements persistent storage for tingbot apps.
It essentially gives you access to a dict-like object (tingbot.config), which will read
default_settings.json, gui_settings.json, and local_settings.json (in increasing priority)
default_settings.json is intended to be created by the app developer and otherwise left unchanged
gui_settings.json is in place so that the app can be configured by the end-user in Tide (or a.n.other IDE)
local_settings.json will contain data stored directly from the app.

I have also put in some test code.

There is a known bug in that if you assign to a subdictionary or list , then it will not automatically save this.
I can't think of a good way to fix this, but have documented it in the documentation.

Usage

```
import tingbot

#store an item
tingbot.config['favourite_colour'] = 'red'

#local_settings.json on disk now contains: {"favourite_colour":"red"}

#retrieve an item
tingbot.screen.fill(tingbot.config['favourite_colour'])
```
