### PR TITLE
FIx concurrency issues while loading images

### DIFF
--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -7,4 +7,5 @@ recursive-exclude * *.py[co]
 recursive-include docs *.rst conf.py Makefile make.bat
 recursive-include tingbot *.png *.ttf *.TTF
 recursive-include tingbot/platform_specific *.py
+recursive-include tests *.png *.gif *.py
 recursive-include tbtool *.key *.key.pub

--- a/tingbot/cache.py
+++ b/tingbot/cache.py
@@ -41,7 +41,7 @@ def get_max_age(response, last_modified):
     except (KeyError, TypeError):
         #really no info from server  so guess based on last-modified
         if last_modified:
-            return min(24*60*60, (get_server_date(response)-last_modified)/10)
+            return min(24*60*60, (get_server_date(response) - last_modified)/10)
         else:
             #not even a last_modified - so conservative guess of 60s
             return 60
@@ -132,10 +132,10 @@ class ImageCache(object):
             image = WebImage(location)
         else:
             image = FileImage(location)
-        self.add_image(location,image)
+        self.add_image(location, image)
         return image.image        
             
-    def add_image(self,location, image):
+    def add_image(self, location, image):
         with self.lock:
             #delete image if already in cache and being over-written
             if location in self.images:
@@ -145,10 +145,10 @@ class ImageCache(object):
 
             #clean out cache if too big
             if self.size > self.cache_size:
-                for key in sorted(self.images, key=lambda a:self.images[a].last_accessed):
-                    if self.size<=self.cache_size:
+                for key in sorted(self.images, key = lambda a:self.images[a].last_accessed):
+                    if self.size <= self.cache_size:
                         break
-                    elif key!=location:
+                    elif key != location:
                         self.del_image(key)
 
     def del_image(self, location):


### PR DESCRIPTION
My previous changes to ImageCache would have meant that HTTP requests for files would have had to run sequentially, rather than parallel, if they had been requested in individual threads. This is clearly less than ideal, so I have re-worked the ImageCache class such that thee network access threads are performed outside of the locked part of the procedure, and only the (fairly quick) dictionary manipulations are performed while protected by the lock
