### PR TITLE
Fix #29 - hardware buttons don't fire 'press' events

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -7,8 +7,5 @@ tag = True
 
 [bumpversion:file:tingbot/__init__.py]
 
-[wheel]
-universal = 1
-
 [pep8]
 ignore = E501,E128,E401,E126,E302

--- a/setup.py
+++ b/setup.py
@@ -1,6 +1,8 @@
 #!/usr/bin/env python
 # -*- coding: utf-8 -*-
 
+import platform
+
 try:
     from setuptools import setup
 except ImportError:
@@ -16,6 +18,9 @@ requirements = [
     'requests',
     'Pillow',
 ]
+
+if 'arm' in platform.machine():
+    requirements.append('RPIO==t1')
 
 setup(
     name='tingbot',
@@ -33,6 +38,7 @@ setup(
                  'tbtool': 'tbtool'},
     include_package_data=True,
     install_requires=requirements,
+    dependency_links=['https://github.com/tingbot/RPIO/archive/t1.zip#egg=RPIO-t1'],
     license="BSD",
     zip_safe=False,
     keywords='tingbot',


### PR DESCRIPTION
Fix #29.

The RPi.GPIO module wasn't giving us up-to-date information about the state of the pins. Possibly because it wasn't reacting to changes that happen while the callbacks are firing. We were missing a lot of 'up' events, which is why this change made it worse - the 'press' event relies on a timely 'up'

If you get a chance, could you test @WhistleMaster? I still need to sort out the dependencies of this change (perhaps post a version of our fork of RPIO to PyPI) - until then it can be installed with 

```
pip install --process-dependency-links https://github.com/tingbot/tingbot-python/archive/buttons-RPIO.zip
```
