### PR TITLE
Set RunLoop up for re-entrant usage

### DIFF
--- a/tingbot/__init__.py
+++ b/tingbot/__init__.py
@@ -19,7 +19,7 @@ except ImportError:
 from . import platform_specific, input, quit
 
 from .graphics import screen, Surface, Image
-from .run_loop import main_run_loop, every, once
+from .run_loop import main_run_loop, create_timer, every, once, RunLoop
 from .input import touch
 from .button import press,left_button,midleft_button,midright_button,right_button
 from .web import webhook
@@ -44,7 +44,7 @@ def run(loop=None):
     main_run_loop.run()
 
 __all__ = [
-    'run', 'screen', 'Surface', 'Image', 'every', 'touch', 'press', 'button', 'webhook',
+    'run', 'screen', 'Surface', 'Image', 'create_timer', 'every', 'once', 'RunLoop', 'touch', 'press', 'button', 'webhook',
     'left_button', 'midleft_button', 'midright_button', 'right_button',
 ]
 __author__ = 'Joe Rickerby'

--- a/tingbot/__init__.py
+++ b/tingbot/__init__.py
@@ -21,12 +21,12 @@ from . import platform_specific, input, quit
 from .graphics import screen, Surface, Image
 from .run_loop import main_run_loop, create_timer, every, once, RunLoop
 from .input import touch
-from .button import press,left_button,midleft_button,midright_button,right_button
+from .button import press, left_button, midleft_button, midright_button, right_button
 from .web import webhook
 from .tingapp import app
 
-#enable deprecation warnings
-warnings.filterwarnings("once",".*",DeprecationWarning)
+# enable deprecation warnings
+warnings.filterwarnings("once", ".*", DeprecationWarning)
 
 platform_specific.fixup_env()
 quit.fixup_sigterm_behaviour()

--- a/tingbot/__init__.py
+++ b/tingbot/__init__.py
@@ -35,16 +35,11 @@ def run(loop=None):
     if loop is not None:
         every(seconds=1.0/30)(loop)
 
-    main_run_loop.add_after_action_callback(screen.update_if_needed)
-
-    main_run_loop.add_wait_callback(input.poll)
-    # in case screen updates happen in input.poll...
-    main_run_loop.add_wait_callback(screen.update_if_needed)
-
     main_run_loop.run()
 
 __all__ = [
-    'run', 'screen', 'Surface', 'Image', 'create_timer', 'every', 'once', 'RunLoop', 'touch', 'press', 'button', 'webhook',
+    'run', 'screen', 'Surface', 'Image', 'create_timer',
+    'every', 'once', 'RunLoop', 'touch', 'press', 'button', 'webhook',
     'left_button', 'midleft_button', 'midright_button', 'right_button',
 ]
 __author__ = 'Joe Rickerby'

--- a/tingbot/button.py
+++ b/tingbot/button.py
@@ -1,7 +1,7 @@
 import time
 import threading
 import warnings
-from collections import namedtuple
+from collections import namedtuple, deque
 import Queue
 
 from .utils import CallbackList
@@ -19,7 +19,7 @@ class Button(object):
         self.hold_time = 1.0
         self.last_hold_check_time = 0
         self.callbacks = {x:CallbackList() for x in action_types}
-        self.actions = []
+        self.actions = deque()
 
     def process_events(self, time):
         while True:
@@ -61,9 +61,9 @@ class Button(object):
         self.actions.append(action)
 
     def run_callbacks(self):
-        for action in self.actions:
+        while self.actions:
+            action = self.actions.popleft()
             self.callbacks[action.type]()
-        self.actions = []
 
     def add_event(self, action, timestamp=None):
         if timestamp is None:

--- a/tingbot/button.py
+++ b/tingbot/button.py
@@ -18,7 +18,7 @@ class Button(object):
         self.last_event = None
         self.hold_time = 1.0
         self.last_hold_check_time = 0
-        self.callbacks = {x:CallbackList() for x in action_types}
+        self.callbacks = {x: CallbackList() for x in action_types}
         self.actions = deque()
 
     def process_events(self, time):
@@ -92,7 +92,7 @@ class Button(object):
 
 # create buttons
 button_names = ('left', 'midleft', 'midright', 'right')
-buttons = {x:Button() for x in button_names}
+buttons = {x: Button() for x in button_names}
 left_button, midleft_button, midright_button, right_button = [buttons[x] for x in button_names]
 
 

--- a/tingbot/cache.py
+++ b/tingbot/cache.py
@@ -34,7 +34,7 @@ def get_max_age(response, last_modified):
     """return how many seconds from original access this response is valid for"""
     try:
         cache_control = response.headers['cache-control']
-        return int(re.match(r"max-age\W*=\W*(\d+)", cache_control).group[1])
+        return int(re.match(r"max-age\W*=\W*(\d+)", cache_control).group(1))
     except (KeyError, ValueError, AttributeError, TypeError):
         pass
     try:

--- a/tingbot/graphics.py
+++ b/tingbot/graphics.py
@@ -147,16 +147,16 @@ class Surface(object):
     def size(self):
         return self.surface.get_size()
 
-    def _fill(self, color, rect = None):
-        if len(color)<=3:
-            self.surface.fill(color,rect)
-        elif len(color)>=4:
-            tmp_surface = pygame.Surface(rect.size,pygame.SRCALPHA)
+    def _fill(self, color, rect=None):
+        if len(color) <= 3:
+            self.surface.fill(color, rect)
+        elif len(color) >= 4:
+            tmp_surface = pygame.Surface(rect.size, pygame.SRCALPHA)
             tmp_surface.fill(color)
-            self.surface.blit(tmp_surface,rect)
+            self.surface.blit(tmp_surface, rect)
 
     def fill(self, color):
-        self._fill(_color(color),self.surface.get_rect())
+        self._fill(_color(color), self.surface.get_rect())
 
     def text(self, string, xy=None, color='grey', align='center', font=None, font_size=32, antialias=None, max_width=sys.maxsize, max_height=sys.maxsize, max_lines=sys.maxsize):
         if xy is None:
@@ -184,7 +184,7 @@ class Surface(object):
 
         xy = _topleft_from_aligned_xy(xy, align, size, self.size)
 
-        self._fill(_color(color), pygame.Rect(xy,size))
+        self._fill(_color(color), pygame.Rect(xy, size))
 
     def line(self, start_xy, end_xy, width=1, color='grey', antialias=True):
         # antialiased thick lines aren't supported by pygame, and the aaline function has some
@@ -353,7 +353,7 @@ class Image(Surface):
         return self.surface.get_buffer().length
 
 class GIFImage(Surface):
-    def __init__(self, image_file): #image_file can be either a file-like object or filename
+    def __init__(self, image_file): # image_file can be either a file-like object or filename
         pygame.init()
         from PIL import Image as PILImage
         self.frames = self._get_frames(PILImage.open(image_file))
@@ -375,7 +375,7 @@ class GIFImage(Surface):
                     pil_image.seek(0)
                 if pil_image.tile:
                     all_tiles.append(pil_image.tile[0][3][0])
-                pil_image.seek(pil_image.tell()+1)
+                pil_image.seek(pil_image.tell() + 1)
         except EOFError:
             pil_image.seek(0)
 
@@ -404,7 +404,7 @@ class GIFImage(Surface):
                     palette = base_palette
             else:
                 palette = base_palette
-            try: # account for different versions of Pillow
+            try:  # account for different versions of Pillow
                 pygame_image = pygame.image.fromstring(pil_image.tobytes(), pil_image.size, pil_image.mode)
             except AttributeError:
                 pygame_image = pygame.image.fromstring(pil_image.tostring(), pil_image.size, pil_image.mode)
@@ -415,7 +415,7 @@ class GIFImage(Surface):
 
             result.append([pygame_image, duration])
             try:
-                pil_image.seek(pil_image.tell()+1)
+                pil_image.seek(pil_image.tell() + 1)
             except EOFError:
                 break
 

--- a/tingbot/graphics.py
+++ b/tingbot/graphics.py
@@ -153,12 +153,12 @@ class Surface(object):
         elif len(color)>=4:
             if rect is None:
                 rect = (0,0)+self.size
-            tmp_surface = pygame.Surface(rect[2:3],pygame.SRCALPHA)
+            tmp_surface = pygame.Surface(rect.size,pygame.SRCALPHA)
             tmp_surface.fill(color)
             self.surface.blit(tmp_surface,rect)
 
     def fill(self, color):
-        self._fill(_color(color))
+        self._fill(_color(color),self.surface.get_rect())
 
     def text(self, string, xy=None, color='grey', align='center', font=None, font_size=32, antialias=None, max_width=sys.maxsize, max_height=sys.maxsize, max_lines=sys.maxsize):
         if xy is None:
@@ -186,7 +186,7 @@ class Surface(object):
 
         xy = _topleft_from_aligned_xy(xy, align, size, self.size)
 
-        self._fill(_color(color), xy+size)
+        self._fill(_color(color), pygame.Rect(xy,size))
 
     def line(self, start_xy, end_xy, width=1, color='grey', antialias=True):
         # antialiased thick lines aren't supported by pygame, and the aaline function has some

--- a/tingbot/graphics.py
+++ b/tingbot/graphics.py
@@ -151,8 +151,6 @@ class Surface(object):
         if len(color)<=3:
             self.surface.fill(color,rect)
         elif len(color)>=4:
-            if rect is None:
-                rect = (0,0)+self.size
             tmp_surface = pygame.Surface(rect.size,pygame.SRCALPHA)
             tmp_surface.fill(color)
             self.surface.blit(tmp_surface,rect)

--- a/tingbot/run_loop.py
+++ b/tingbot/run_loop.py
@@ -3,13 +3,13 @@ from .utils import Struct, CallbackList
 from . import error
 
 class Timer(Struct):
-    def __init__(self,**kwargs):
+    def __init__(self, **kwargs):
         self.active = True
-        super(Timer,self).__init__(**kwargs)
+        super(Timer, self).__init__(**kwargs)
 
     def stop(self):
         self.active = False
-        
+
     def run(self):
         if self.active:
             self.action()
@@ -24,12 +24,12 @@ class every(object):
         return f
 
 def create_timer(action, hours=0, minutes=0, seconds=0, period=0, repeating=True, background=False):
-    if period==0:
-        period = (hours * 60 + minutes) * 60 + seconds        
+    if period == 0:
+        period = (hours * 60 + minutes) * 60 + seconds
     timer = Timer(action=action, period=period, repeating=repeating, next_fire_time=None, background=background)
     RunLoop.schedule(timer)
     return timer
-    
+
 
 class once(object):
     def __init__(self, hours=0, minutes=0, seconds=0, background=False):
@@ -41,7 +41,9 @@ class once(object):
         return f
 
 class RunLoop(object):
+
     stack = []
+
     def __init__(self, parent=None):
         if parent:
             self.timers = [x for x in parent.timers if x.background]
@@ -62,12 +64,11 @@ class RunLoop(object):
         else:
             run_loop = cls()
         return run_loop
-            
 
     @classmethod
-    def schedule(cls,timer):
+    def schedule(cls, timer):
         cls.stack[-1]._schedule(timer)
-        
+
     def _schedule(self, timer):
         if timer.next_fire_time is None:
             if timer.repeating:
@@ -106,7 +107,7 @@ class RunLoop(object):
                 except Exception as e:
                     self._error(e)
         self.running = True  # prevent an outer loop from stopping if inner loop has been stopped
-        self.stack.pop()  # remove this run_loop from the stack  
+        self.stack.pop()  # remove this run_loop from the stack
 
     @classmethod
     def stop(cls):

--- a/tingbot/run_loop.py
+++ b/tingbot/run_loop.py
@@ -34,7 +34,7 @@ class RunLoop(object):
         self._wait_callbacks = CallbackList()
         self._before_action_callbacks = CallbackList()
         self._after_action_callbacks = CallbackList()
-        self.current_timers= []
+        self.current_timers = []
 
     def schedule(self, timer):
         if timer.next_fire_time is None:
@@ -48,16 +48,15 @@ class RunLoop(object):
         self.timers.append(timer)
         self.timers.sort(key=operator.attrgetter('next_fire_time'), reverse=True)
 
-    def remove_timer(self,action):
+    def remove_timer(self, action):
         """remove a timer from the list"""
         if self.current_timers:
             current_action = self.current_timers[-1].action
         else:
             current_action = None
-        if (action not in [x.action for x in self.timers] 
-            and action != current_action):
-                raise ValueError("Timer not found")
-        if current_action == action: #account for being called from the timer requesting being stopped
+        if action != current_action and action not in [x.action for x in self.timers]:
+            raise ValueError("Timer not found")
+        if current_action == action:  # account for being called from the timer requesting being stopped
             self.current_timers[-1].repeating = False
         self.timers[:] = [x for x in self.timers if x.action != action]
 
@@ -88,7 +87,7 @@ class RunLoop(object):
                     self._wait(start_time + 0.1)
                 except Exception as e:
                     self._error(e)
-        self.running = True #prevent an outer loop from stopping if inner loop has been stopped
+        self.running = True  # prevent an outer loop from stopping if inner loop has been stopped
 
     def stop(self):
         self.running = False

--- a/tingbot/utils.py
+++ b/tingbot/utils.py
@@ -14,6 +14,11 @@ class CallbackList(object):
 
     def add(self, callback):
         self._list.append(callback)
+        
+    def copy(self):
+        obj = CallbackList()
+        obj._list = self._list[:]
+        return obj
 
 
 # cached_property from werkzeug

--- a/tingbot/utils.py
+++ b/tingbot/utils.py
@@ -14,7 +14,7 @@ class CallbackList(object):
 
     def add(self, callback):
         self._list.append(callback)
-        
+
     def copy(self):
         obj = CallbackList()
         obj._list = self._list[:]


### PR DESCRIPTION
This PR allows my GUI code to start it's own iteration of RunLoop.run to allow for dialogs to run "modally" while still keeping events specified by `every` and `once` to run as normal. I've also added some code to simplify cancelling an `every` timer from within that timer.
Also small bug-fix in graphics module
